### PR TITLE
ユーザー設定機能の実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,12 @@ Style/Documentation:
 
 RSpec/ContextWording:
   Enabled: false
+
+RSpec/ExampleLength:
+  Max: 10
+
+RSpec/MultipleExpectations:
+  Max: 3
+
+Rails/LexicallyScopedActionFilter:
+  Enabled: false

--- a/app/assets/stylesheets/user.scss
+++ b/app/assets/stylesheets/user.scss
@@ -11,16 +11,10 @@
 
 * { -webkit-box-sizing:border-box; -moz-box-sizing:border-box; -ms-box-sizing:border-box; -o-box-sizing:border-box; box-sizing:border-box; }
 
-html { width: 100%; height:100%; overflow:hidden; }
-
-
 .login {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  margin: -150px 0 0 -150px;
-  width:300px;
-  height:300px;
+  width: 30%;
+  margin: auto;
+  padding-top: 180px;
 }
 
 .login h1 {
@@ -55,4 +49,39 @@ input:focus { box-shadow: inset 0 -5px 45px rgba(100,100,100,0.4), 0 1px 1px rgb
 
 .actions {
   margin-top: 5px;
+}
+
+.main-container {
+  background: -moz-radial-gradient(0% 100%, ellipse cover, rgba(50,70,80,.4) 10%,rgba(60,50,40,0) 40%),-moz-linear-gradient(top,  rgba(30,50,60,.25) 0%, rgba(20,30,40,.4) 100%), -moz-linear-gradient(-45deg,  #330d10 0%, #091236 100%);
+  background: -webkit-radial-gradient(0% 100%, ellipse cover, rgba(50,70,80,.4) 10%,rgba(60,50,40,0) 40%), -webkit-linear-gradient(top,  rgba(30,50,60,.25) 0%,rgba(20,30,40,.4) 100%), -webkit-linear-gradient(-45deg,  #330d10 0%,#091236 100%);
+  background: -o-radial-gradient(0% 100%, ellipse cover, rgba(50,70,80,.4) 10%,rgba(60,50,40,0) 40%), -o-linear-gradient(top,  rgba(30,50,60,.25) 0%,rgba(20,30,40,.4) 100%), -o-linear-gradient(-45deg,  #330d10 0%,#091236 100%);
+  background: -ms-radial-gradient(0% 100%, ellipse cover, rgba(50,70,80,.4) 10%,rgba(60,50,40,0) 40%), -ms-linear-gradient(top,  rgba(30,50,60,.25) 0%,rgba(20,30,40,.4) 100%), -ms-linear-gradient(-45deg,  #330d10 0%,#091236 100%);
+  background: -webkit-radial-gradient(0% 100%, ellipse cover, rgba(50,70,80,.4) 10%,rgba(60,50,40,0) 40%), linear-gradient(to bottom,  rgba(30,50,60,.25) 0%,rgba(20,30,40,.4) 100%), linear-gradient(135deg,  #330d10 0%,#091236 100%);
+  padding: 20px;
+  height: 1000px;
+}
+
+.edit-contents {
+  color: white;
+  border-radius: 8px;
+  padding-top: 50px;
+}
+
+.form-control {
+  background-color: #444;
+  color: #fff;
+}
+
+.btn-outline-dark {
+  border-color: #fff;
+  color: #fff;
+}
+
+.btn-outline-dark:hover {
+  background-color: #555;
+  border-color: #fff;
+}
+
+.myprofile {
+  padding-top: 80px;
 }

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,30 +1,32 @@
 # frozen_string_literal: true
 
-class Users::ConfirmationsController < Devise::ConfirmationsController
-  # GET /resource/confirmation/new
-  # def new
-  #   super
-  # end
+module Users
+  class ConfirmationsController < Devise::ConfirmationsController
+    # GET /resource/confirmation/new
+    # def new
+    #   super
+    # end
 
-  # POST /resource/confirmation
-  # def create
-  #   super
-  # end
+    # POST /resource/confirmation
+    # def create
+    #   super
+    # end
 
-  # GET /resource/confirmation?confirmation_token=abcdef
-  # def show
-  #   super
-  # end
+    # GET /resource/confirmation?confirmation_token=abcdef
+    # def show
+    #   super
+    # end
 
-  # protected
+    # protected
 
-  # The path used after resending confirmation instructions.
-  # def after_resending_confirmation_instructions_path_for(resource_name)
-  #   super(resource_name)
-  # end
+    # The path used after resending confirmation instructions.
+    # def after_resending_confirmation_instructions_path_for(resource_name)
+    #   super(resource_name)
+    # end
 
-  # The path used after confirmation.
-  # def after_confirmation_path_for(resource_name, resource)
-  #   super(resource_name, resource)
-  # end
+    # The path used after confirmation.
+    # def after_confirmation_path_for(resource_name, resource)
+    #   super(resource_name, resource)
+    # end
+  end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,30 +1,32 @@
 # frozen_string_literal: true
 
-class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  # You should configure your model like this:
-  # devise :omniauthable, omniauth_providers: [:twitter]
+module Users
+  class OmniauthCallbacksController < Devise::OmniauthCallbacksController
+    # You should configure your model like this:
+    # devise :omniauthable, omniauth_providers: [:twitter]
 
-  # You should also create an action method in this controller like this:
-  # def twitter
-  # end
+    # You should also create an action method in this controller like this:
+    # def twitter
+    # end
 
-  # More info at:
-  # https://github.com/heartcombo/devise#omniauth
+    # More info at:
+    # https://github.com/heartcombo/devise#omniauth
 
-  # GET|POST /resource/auth/twitter
-  # def passthru
-  #   super
-  # end
+    # GET|POST /resource/auth/twitter
+    # def passthru
+    #   super
+    # end
 
-  # GET|POST /users/auth/twitter/callback
-  # def failure
-  #   super
-  # end
+    # GET|POST /users/auth/twitter/callback
+    # def failure
+    #   super
+    # end
 
-  # protected
+    # protected
 
-  # The path used when OmniAuth fails
-  # def after_omniauth_failure_path_for(scope)
-  #   super(scope)
-  # end
+    # The path used when OmniAuth fails
+    # def after_omniauth_failure_path_for(scope)
+    #   super(scope)
+    # end
+  end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/heartcombo/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,34 +1,36 @@
 # frozen_string_literal: true
 
-class Users::PasswordsController < Devise::PasswordsController
-  # GET /resource/password/new
-  # def new
-  #   super
-  # end
+module Users
+  class PasswordsController < Devise::PasswordsController
+    # GET /resource/password/new
+    # def new
+    #   super
+    # end
 
-  # POST /resource/password
-  # def create
-  #   super
-  # end
+    # POST /resource/password
+    # def create
+    #   super
+    # end
 
-  # GET /resource/password/edit?reset_password_token=abcdef
-  # def edit
-  #   super
-  # end
+    # GET /resource/password/edit?reset_password_token=abcdef
+    # def edit
+    #   super
+    # end
 
-  # PUT /resource/password
-  # def update
-  #   super
-  # end
+    # PUT /resource/password
+    # def update
+    #   super
+    # end
 
-  # protected
+    # protected
 
-  # def after_resetting_password_path_for(resource)
-  #   super(resource)
-  # end
+    # def after_resetting_password_path_for(resource)
+    #   super(resource)
+    # end
 
-  # The path used after sending reset password instructions
-  # def after_sending_reset_password_instructions_path_for(resource_name)
-  #   super(resource_name)
-  # end
+    # The path used after sending reset password instructions
+    # def after_sending_reset_password_instructions_path_for(resource_name)
+    #   super(resource_name)
+    # end
+  end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :configure_sign_up_params, only: [:create]
+  before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  protected
+
+  def configure_sign_up_params
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
+  end
+
+  def configure_account_update_params
+    devise_parameter_sanitizer.permit(:account_update, keys: [:username])
+  end
+
+  def update_resource(resource, params)
+    if params[:email] != resource.email || params[:password].present?
+      super
+    else
+      cleaned_params = params.except("current_password")
+      resource.update_without_password(cleaned_params)
+    end
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,81 +1,83 @@
 # frozen_string_literal: true
 
-class Users::RegistrationsController < Devise::RegistrationsController
-  before_action :configure_sign_up_params, only: [:create]
-  before_action :configure_account_update_params, only: [:update]
+module Users
+  class RegistrationsController < Devise::RegistrationsController
+    before_action :configure_sign_up_params, only: [:create]
+    before_action :configure_account_update_params, only: [:update]
 
-  # GET /resource/sign_up
-  # def new
-  #   super
-  # end
+    # GET /resource/sign_up
+    # def new
+    #   super
+    # end
 
-  # POST /resource
-  # def create
-  #   super
-  # end
+    # POST /resource
+    # def create
+    #   super
+    # end
 
-  # GET /resource/edit
-  # def edit
-  #   super
-  # end
+    # GET /resource/edit
+    # def edit
+    #   super
+    # end
 
-  # PUT /resource
-  # def update
-  #   super
-  # end
+    # PUT /resource
+    # def update
+    #   super
+    # end
 
-  # DELETE /resource
-  # def destroy
-  #   super
-  # end
+    # DELETE /resource
+    # def destroy
+    #   super
+    # end
 
-  # GET /resource/cancel
-  # Forces the session data which is usually expired after sign
-  # in to be expired now. This is useful if the user wants to
-  # cancel oauth signing in/up in the middle of the process,
-  # removing all OAuth session data.
-  # def cancel
-  #   super
-  # end
+    # GET /resource/cancel
+    # Forces the session data which is usually expired after sign
+    # in to be expired now. This is useful if the user wants to
+    # cancel oauth signing in/up in the middle of the process,
+    # removing all OAuth session data.
+    # def cancel
+    #   super
+    # end
 
-  # protected
+    # protected
 
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
-  # end
+    # If you have extra params to permit, append them to the sanitizer.
+    # def configure_sign_up_params
+    #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+    # end
 
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_account_update_params
-  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
-  # end
+    # If you have extra params to permit, append them to the sanitizer.
+    # def configure_account_update_params
+    #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+    # end
 
-  # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+    # The path used after sign up.
+    # def after_sign_up_path_for(resource)
+    #   super(resource)
+    # end
 
-  # The path used after sign up for inactive accounts.
-  # def after_inactive_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+    # The path used after sign up for inactive accounts.
+    # def after_inactive_sign_up_path_for(resource)
+    #   super(resource)
+    # end
 
-  protected
+    protected
 
-  def configure_sign_up_params
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
-  end
+    def configure_sign_up_params
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
+    end
 
-  def configure_account_update_params
-    devise_parameter_sanitizer.permit(:account_update, keys: [:username])
-  end
+    def configure_account_update_params
+      devise_parameter_sanitizer.permit(:account_update, keys: [:username])
+    end
 
-  def update_resource(resource, params)
-    if params[:email] != resource.email || params[:password].present?
-      super
-    else
-      cleaned_params = params.except("current_password")
-      resource.update_without_password(cleaned_params)
+    def update_resource(resource, params)
+      if params[:email] != resource.email || params[:password].present?
+        super
+      else
+        cleaned_params = params.except("current_password")
+        resource.update_without_password(cleaned_params)
+      end
     end
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,27 +1,29 @@
 # frozen_string_literal: true
 
-class Users::SessionsController < Devise::SessionsController
-  # before_action :configure_sign_in_params, only: [:create]
+module Users
+  class SessionsController < Devise::SessionsController
+    # before_action :configure_sign_in_params, only: [:create]
 
-  # GET /resource/sign_in
-  # def new
-  #   super
-  # end
+    # GET /resource/sign_in
+    # def new
+    #   super
+    # end
 
-  # POST /resource/sign_in
-  # def create
-  #   super
-  # end
+    # POST /resource/sign_in
+    # def create
+    #   super
+    # end
 
-  # DELETE /resource/sign_out
-  # def destroy
-  #   super
-  # end
+    # DELETE /resource/sign_out
+    # def destroy
+    #   super
+    # end
 
-  # protected
+    # protected
 
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_in_params
-  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
-  # end
+    # If you have extra params to permit, append them to the sanitizer.
+    # def configure_sign_in_params
+    #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+    # end
+  end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,30 +1,32 @@
 # frozen_string_literal: true
 
-class Users::UnlocksController < Devise::UnlocksController
-  # GET /resource/unlock/new
-  # def new
-  #   super
-  # end
+module Users
+  class UnlocksController < Devise::UnlocksController
+    # GET /resource/unlock/new
+    # def new
+    #   super
+    # end
 
-  # POST /resource/unlock
-  # def create
-  #   super
-  # end
+    # POST /resource/unlock
+    # def create
+    #   super
+    # end
 
-  # GET /resource/unlock?unlock_token=abcdef
-  # def show
-  #   super
-  # end
+    # GET /resource/unlock?unlock_token=abcdef
+    # def show
+    #   super
+    # end
 
-  # protected
+    # protected
 
-  # The path used after sending unlock password instructions
-  # def after_sending_unlock_instructions_path_for(resource)
-  #   super(resource)
-  # end
+    # The path used after sending unlock password instructions
+    # def after_sending_unlock_instructions_path_for(resource)
+    #   super(resource)
+    # end
 
-  # The path used after unlocking the resource
-  # def after_unlock_path_for(resource)
-  #   super(resource)
-  # end
+    # The path used after unlocking the resource
+    # def after_unlock_path_for(resource)
+    #   super(resource)
+    # end
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,7 @@
+class UsersController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+    @user = current_user
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  validates :username, presence: true, length: { maximum: 10 }
 end

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Resend confirmation instructions</h2>
 
 <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
+  <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
     <%= f.label :email %><br />
@@ -13,4 +13,4 @@
   </div>
 <% end %>
 
-<%= render "users/shared/links" %>
+<%= render "devise/shared/links" %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -22,4 +22,4 @@
   </div>
 <% end %>
 
-<%= render "users/shared/links" %>
+<%= render "devise/shared/links" %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,13 @@
-<h2>Forgot your password?</h2>
-
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<div class="main">
+  <div class="login">
+    <h2 class="text-white">パスワードを忘れましたか？</h2>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+      <div class="field">
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Email", required: "required" %>
+      </div>
+      <div class="actions">
+        <%= f.submit "パスワードをリセット", class: "btn btn-primary btn-block btn-large" %>
+      </div>
+    <% end %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -7,10 +7,10 @@
         <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'form-group' }) do |f| %>
           <%= render "devise/shared/error_messages", resource: resource %>
           <div class="mb-3">
-            <%= f.text_field :username, autofocus: true, autocomplete: "username", class: 'form-control', required: "required" %>
+            <%= f.text_field :username, autofocus: true, autocomplete: "username", placeholder: "ユーザーネーム", class: 'form-control', required: "required" %>
           </div>
           <div class="mb-3">
-            <%= f.email_field :email, autocomplete: "email", class: 'form-control', required: "required" %>
+            <%= f.email_field :email, autocomplete: "email", placeholder: "メールアドレス", class: 'form-control', required: "required" %>
           </div>
           <div class="mb-3">
             <%= f.password_field :password, autocomplete: "new-password", class: 'form-control', placeholder: "新しいパスワード" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,31 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
-
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<div class="main-container">
+  <div class="edit-contents">
+    <h1 class="text-center">ユーザー情報の編集</h1>
+    <small class="text-secondary d-block mb-4 text-center">メールアドレスとパスワードを変更する場合は現在のパスワードの入力が必要です</small>
+    <div class="row justify-content-center">
+      <div class="col-md-6">
+        <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'form-group' }) do |f| %>
+          <%= render "devise/shared/error_messages", resource: resource %>
+          <div class="mb-3">
+            <%= f.text_field :username, autofocus: true, autocomplete: "username", class: 'form-control', required: "required" %>
+          </div>
+          <div class="mb-3">
+            <%= f.email_field :email, autocomplete: "email", class: 'form-control', required: "required" %>
+          </div>
+          <div class="mb-3">
+            <%= f.password_field :password, autocomplete: "new-password", class: 'form-control', placeholder: "新しいパスワード" %>
+          </div>
+          <div class="mb-3">
+            <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'form-control', placeholder: "新しいパスワード（確認用）" %>
+          </div>
+          <div class="mb-3">
+            <%= f.password_field :current_password, autocomplete: "current-password", class: 'form-control', placeholder: "現在のパスワード" %>
+          </div>
+          <div class="actions">
+            <%= f.submit "変更" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
   </div>
-
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,18 +1,21 @@
 <div class="main">
   <div class="login">
     <h1>新規登録</h1>
-    <%= form_with(model: resource, as: resource_name, url: registration_path(resource_name), local: true) do |f| %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
       <div class="field">
-        <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Email", required: "required" %>
+        <%= f.text_field :username, autofocus: true, autocomplete: "username", placeholder: "ユーザーネーム", required: "required" %>
       </div>
       <div class="field">
-        <%= f.password_field :password, autocomplete: "new-password", placeholder: "Password", required: "required" %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス", required: "required" %>
       </div>
       <div class="field">
-        <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "Password Confirmation", required: "required" %>
+        <%= f.password_field :password, autocomplete: "current-password", placeholder: "パスワード", required: "required" %>
+      </div>
+      <div class="field">
+        <%= f.password_field :password_confirmation, autocomplete: "current-password", placeholder: "確認用パスワード", required: "required" %>
       </div>
       <div class="actions">
-        <%= f.submit "Sign Up", class: "btn btn-primary btn-block btn-large" %>
+        <%= f.submit "GO", class: "btn btn-primary btn-block btn-large" %>
       </div>
     <% end %>
   </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -2,6 +2,7 @@
   <div class="login">
     <h1>新規登録</h1>
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
       <div class="field">
         <%= f.text_field :username, autofocus: true, autocomplete: "username", placeholder: "ユーザーネーム", required: "required" %>
       </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -12,6 +12,9 @@
         <%= f.submit "GO", class: "btn btn-primary btn-block btn-large" %>
       </div>
     <% end %>
+    <small class="text-secondary d-block mb-4 text-center">
+      <%= link_to "パスワードを忘れましたか？", new_user_password_path, class: "text-secondary", style: "text-decoration: none;" %>
+    </small>
   </div>
 </div>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,6 +2,7 @@
   <div class="login">
     <h1>ログイン</h1>
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
       <div class="field">
         <%= f.text_field :email, autofocus: true, autocomplete: "email", placeholder: "Email", required: "required" %>
       </div>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Resend unlock instructions</h2>
 
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
+  <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
     <%= f.label :email %><br />

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.1/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 
   <body>
@@ -34,9 +35,9 @@
               <%= link_to '統計', '#', class: 'nav-link' %>
             </li>
             <li class="nav-item dropdown">
-              <%= link_to '', '#', class: 'nav-link dropdown-toggle', 'data-toggle': 'dropdown', 'aria-haspopup': 'true', 'aria-expanded': 'false' %>
+              <%= link_to  current_user.username , '#', class: 'nav-link dropdown-toggle', 'data-toggle': 'dropdown', 'aria-haspopup': 'true', 'aria-expanded': 'false' %>
               <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-                <%= link_to 'マイページ', '#', class: 'dropdown-item' %>
+                <%= link_to 'マイページ', mypage_path, class: 'dropdown-item' %>
                 <%= link_to '登録アーティスト', '#', class: 'dropdown-item' %>
                 <%= link_to '登録会場', '#', class: 'dropdown-item' %>
                 <div class="dropdown-divider"></div>
@@ -55,6 +56,6 @@
       </div>
     </nav>
     <%= yield %>
-    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+
   </body>
 </html>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,18 @@
+<div class="main-container text-center myprofile">
+  <% if @user.avatar.present? %>
+    <img src="<%= @user.avatar.url %>" alt="<%= @user.username %>'s Image" class="img-fluid rounded-circle mb-3" style="width: 100px; height: 100px;">
+  <% end %>
+  <h1 class="display-3" style="color: #F5F5F5;"><%= @user.username %></h1>
+  <p class="lead" style="font-size: 2em; color: #F5F5F5;">Email: <%= @user.email %></p>
+  <p class="lead" style="font-size: 2em; color: #F5F5F5;">Password: *********
+    <%= link_to edit_user_registration_path do %>
+      <i class="fas fa-edit ml-2" style="color: darkgrey;"></i>
+    <% end %>
+  </p>
+  <div class="mt-2">
+    <%= button_to "アカウントを削除", registration_path(current_user),
+          data: { confirm: "本当に削除して良いですか?", turbo_confirm: "Are you sure?" },
+          method: :delete,
+          class: "btn btn-sm w-auto" %>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,5 @@
 <div class="main-container text-center myprofile">
+  <h1 class="display-3" style="color: #F5F5F5;">マイページ</h1>
   <% if @user.avatar.present? %>
     <img src="<%= @user.avatar.url %>" alt="<%= @user.username %>'s Image" class="img-fluid rounded-circle mb-3" style="width: 100px; height: 100px;">
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
+  get 'users/show'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  devise_for :users
+  devise_for :users, controllers: {
+    registrations: 'users/registrations'
+  }
+  get 'mypage', to: 'users#show'
   root 'home#index'
 end

--- a/db/migrate/20230918105507_add_username_to_users.rb
+++ b/db/migrate/20230918105507_add_username_to_users.rb
@@ -1,0 +1,5 @@
+class AddUsernameToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :username, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_17_021057) do
+ActiveRecord::Schema.define(version: 2023_09_18_105507) do
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2023_09_17_021057) do
     t.string "avatar"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "username"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :user do
+    username { "username" }
     email { Faker::Internet.email }
     password { "password" }
     password_confirmation { "password" }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,6 +33,8 @@ end
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include Devise::Test::IntegrationHelpers, type: :system
+  config.include Devise::Test::IntegrationHelpers, type: :request
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = Rails.root.join('spec/fixtures').to_s
 

--- a/spec/requests/users/user_edit_spec.rb
+++ b/spec/requests/users/user_edit_spec.rb
@@ -1,38 +1,27 @@
 require 'rails_helper'
 
-RSpec.describe 'ユーザー編集', type: :request do
+RSpec.describe 'ユーザー編集' do
   describe 'PUT /users' do
     let(:user) { create(:user) }
-    let(:新しいユーザーネーム) { '新しいユーザーネーム' }
-    let(:新しいメールアドレス) { Faker::Internet.email }
+    let(:new_username) { 'ユーザー' }
+    let(:new_email) { Faker::Internet.email }
 
     before do
       sign_in user
       get edit_user_registration_path
     end
 
-    context 'ユーザーネームだけを更新する場合' do
-      it 'ユーザーネームが更新される' do
-        put user_registration_path, params: { user: { username: 新しいユーザーネーム } }
-        expect(response).to redirect_to(root_path)
-        expect(user.reload.username).to eq(新しいユーザーネーム)
-      end
+    it '現在のパスワードなしではユーザーネームとメールアドレスが更新されない' do
+      put user_registration_path, params: { user: { username: new_username, email: new_email } }
+      expect(user.reload.username).not_to eq(new_username)
+      expect(user.reload.email).not_to eq(new_email)
     end
 
-    context 'ユーザーネームとメールアドレスを更新する場合' do
-      it '現在のパスワードなしではユーザーネームとメールアドレスが更新されない' do
-        put user_registration_path, params: { user: { username: 新しいユーザーネーム, email: 新しいメールアドレス } }
-        expect(response).to redirect_to(edit_user_registration_path)
-        expect(user.reload.username).not_to eq(新しいユーザーネーム)
-        expect(user.reload.email).not_to eq(新しいメールアドレス)
-      end
-
-      it '現在のパスワードありでユーザーネームとメールアドレスが更新される' do
-        put user_registration_path, params: { user: { username: 新しいユーザーネーム, email: 新しいメールアドレス, current_password: user.password } }
-        expect(response).to redirect_to(root_path)
-        expect(user.reload.username).to eq(新しいユーザーネーム)
-        expect(user.reload.email).to eq(新しいメールアドレス)
-      end
+    it '現在のパスワードありでユーザーネームとメールアドレスが更新される' do
+      put user_registration_path, params: { user: { username: new_username, email: new_email, current_password: user.password } }
+      expect(response).to redirect_to(root_path)
+      expect(user.reload.username).to eq(new_username)
+      expect(user.reload.email).to eq(new_email)
     end
   end
 end

--- a/spec/requests/users/user_edit_spec.rb
+++ b/spec/requests/users/user_edit_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'ユーザー編集', type: :request do
+  describe 'PUT /users' do
+    let(:user) { create(:user) }
+    let(:新しいユーザーネーム) { '新しいユーザーネーム' }
+    let(:新しいメールアドレス) { Faker::Internet.email }
+
+    before do
+      sign_in user
+      get edit_user_registration_path
+    end
+
+    context 'ユーザーネームだけを更新する場合' do
+      it 'ユーザーネームが更新される' do
+        put user_registration_path, params: { user: { username: 新しいユーザーネーム } }
+        expect(response).to redirect_to(root_path)
+        expect(user.reload.username).to eq(新しいユーザーネーム)
+      end
+    end
+
+    context 'ユーザーネームとメールアドレスを更新する場合' do
+      it '現在のパスワードなしではユーザーネームとメールアドレスが更新されない' do
+        put user_registration_path, params: { user: { username: 新しいユーザーネーム, email: 新しいメールアドレス } }
+        expect(response).to redirect_to(edit_user_registration_path)
+        expect(user.reload.username).not_to eq(新しいユーザーネーム)
+        expect(user.reload.email).not_to eq(新しいメールアドレス)
+      end
+
+      it '現在のパスワードありでユーザーネームとメールアドレスが更新される' do
+        put user_registration_path, params: { user: { username: 新しいユーザーネーム, email: 新しいメールアドレス, current_password: user.password } }
+        expect(response).to redirect_to(root_path)
+        expect(user.reload.username).to eq(新しいユーザーネーム)
+        expect(user.reload.email).to eq(新しいメールアドレス)
+      end
+    end
+  end
+end

--- a/spec/requests/users/user_registration_spec.rb
+++ b/spec/requests/users/user_registration_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe "User Registrations" do
+  describe "POST /users" do
+    let(:valid_attributes) { attributes_for(:user) }
+    let(:invalid_attributes) { attributes_for(:user, username: "") }
+
+    it "ユーザーが正常に登録されること" do
+      post user_registration_path, params: { user: valid_attributes }
+      expect(response).to redirect_to(root_path)
+      expect(User.last.username).to eq("username")
+    end
+
+    it "ユーザーが登録されないこと" do
+      post user_registration_path, params: { user: invalid_attributes }
+      expect(User.count).to eq(0)
+    end
+  end
+end

--- a/spec/requests/users_mypage_spec.rb
+++ b/spec/requests/users_mypage_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe "MyPage", type: :request do
+RSpec.describe "MyPage" do
   describe "GET /mypage" do
-
     let(:user) { create(:user) }
+
     before do
       sign_in user
       get mypage_path

--- a/spec/requests/users_mypage_spec.rb
+++ b/spec/requests/users_mypage_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe "MyPage", type: :request do
+  describe "GET /mypage" do
+
+    let(:user) { create(:user) }
+    before do
+      sign_in user
+      get mypage_path
+    end
+
+    it 'レスポンスが正しく返されること' do
+      expect(response).to be_successful
+    end
+
+    it 'usernameが表示されること' do
+      expect(response.body).to include(user.username)
+    end
+
+    it 'emailが表示されること' do
+      expect(response.body).to include(user.email)
+    end
+  end
+end

--- a/spec/system/users/user_edit_spec.rb
+++ b/spec/system/users/user_edit_spec.rb
@@ -1,41 +1,42 @@
 require 'rails_helper'
 
-RSpec.describe "UserEdits", type: :system do
+RSpec.describe "UserEdits" do
   describe "username update" do
-  let(:user) { create(:user) }
+    let(:user) { create(:user) }
+    let(:new_email) { Faker::Internet.email }
 
-  before do
-    sign_in user
-    visit edit_user_registration_path
-    new_email = Faker::Internet.email
-  end
-
-  context "usernameのみ変更する場合" do
-    it "usernameが変更できること" do
-      fill_in "ユーザーネーム", with: "new_username"
-      click_button "変更"
-      expect(current_path).to eq(root_path)
-      expect(user.reload.username).to eq(new_username)
-    end
-  end
-
-  context "username以外も変更する場合" do
-    it "usernameとemailを変更できないこと" do
-      fill_in "ユーザーネーム", with: "new_username"
-      fill_in "メールアドレス", with: Faker::Internet.email
-      click_button "変更"
-      expect(current_path).to eq(edit_user_registration_path)
-      expect(user.reload.email).not_to eq(new_email)
+    before do
+      sign_in user
+      visit edit_user_registration_path
     end
 
-    it 'usernameとemailを変更できること' do
-      fill_in "ユーザーネーム", with: "new_username"
-      fill_in "メールアドレス", with: Faker::Internet.email
-      fill_in "現在のパスワード", with: "password"
-      click_button "変更"
-      expect(current_path).to eq(root_path)
-      expect(user.reload.username).to eq(new_username)
-      expect(user.reload.email).to eq(new_email)
+    context "usernameのみ変更する場合" do
+      it "usernameが変更できること" do
+        fill_in "ユーザーネーム", with: "new"
+        click_button "変更"
+        expect(page).to have_current_path(root_path)
+        expect(user.reload.username).to eq("new")
+      end
+    end
+
+    context "username以外も変更する場合" do
+      it "usernameとemailを変更できないこと" do
+        fill_in "ユーザーネーム", with: "new"
+        fill_in "メールアドレス", with: new_email
+        click_button "変更"
+        expect(user.reload.email).not_to eq(user.username)
+        expect(user.reload.email).not_to eq(new_email)
+      end
+
+      it 'usernameとemailを変更できること' do
+        fill_in "ユーザーネーム", with: "new"
+        fill_in "メールアドレス", with: new_email
+        fill_in "現在のパスワード", with: "password"
+        click_button "変更"
+        expect(page).to have_current_path(root_path)
+        expect(user.reload.username).to eq("new")
+        expect(user.reload.email).to eq(new_email)
+      end
     end
   end
 end

--- a/spec/system/users/user_edit_spec.rb
+++ b/spec/system/users/user_edit_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe "UserEdits", type: :system do
+  describe "username update" do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in user
+    visit edit_user_registration_path
+    new_email = Faker::Internet.email
+  end
+
+  context "usernameのみ変更する場合" do
+    it "usernameが変更できること" do
+      fill_in "ユーザーネーム", with: "new_username"
+      click_button "変更"
+      expect(current_path).to eq(root_path)
+      expect(user.reload.username).to eq(new_username)
+    end
+  end
+
+  context "username以外も変更する場合" do
+    it "usernameとemailを変更できないこと" do
+      fill_in "ユーザーネーム", with: "new_username"
+      fill_in "メールアドレス", with: Faker::Internet.email
+      click_button "変更"
+      expect(current_path).to eq(edit_user_registration_path)
+      expect(user.reload.email).not_to eq(new_email)
+    end
+
+    it 'usernameとemailを変更できること' do
+      fill_in "ユーザーネーム", with: "new_username"
+      fill_in "メールアドレス", with: Faker::Internet.email
+      fill_in "現在のパスワード", with: "password"
+      click_button "変更"
+      expect(current_path).to eq(root_path)
+      expect(user.reload.username).to eq(new_username)
+      expect(user.reload.email).to eq(new_email)
+    end
+  end
+end

--- a/spec/system/users/user_registration_spec.rb
+++ b/spec/system/users/user_registration_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe "UserRegistration" do
+  it "usernameが正しく登録されること" do
+    visit new_user_registration_path
+    fill_in "ユーザーネーム", with: "username"
+    fill_in "メールアドレス", with: "test@example.com"
+    fill_in "パスワード", with: "password"
+    fill_in "確認用パスワード", with: "password"
+
+    click_button "GO"
+    expect(page).to have_current_path(root_path, ignore_query: true)
+  end
+end

--- a/spec/system/users_mypage_spec.rb
+++ b/spec/system/users_mypage_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe "MyPage", type: :system do
+  let(:user) { create(:user) }
+
+  context "ログイン前の場合" do
+    it "マイページでログインリダイレクトされること" do
+      visit mypage_path
+      expect(current_path).to eq(new_user_session_path)
+    end
+  end
+
+  context "ログイン中の場合" do
+    before do
+      login_as(user)
+      visit mypage_path
+    end
+
+    it "usernameが正しく表示されること" do
+      expect(page).to have_content(user.email)
+    end
+
+    it "emailが正しく表示されること" do
+      expect(page).to have_content(user.email)
+    end
+
+    it "編集アイコンで編集ページにアクセスできること" do
+      find("i.fas.fa-edit").click
+      expect(current_path).to eq(edit_user_registration_path)
+    end
+  end
+end

--- a/spec/system/users_mypage_spec.rb
+++ b/spec/system/users_mypage_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-RSpec.describe "MyPage", type: :system do
+RSpec.describe "MyPage" do
   let(:user) { create(:user) }
 
   context "ログイン前の場合" do
     it "マイページでログインリダイレクトされること" do
       visit mypage_path
-      expect(current_path).to eq(new_user_session_path)
+      expect(page).to have_current_path(new_user_session_path, ignore_query: true)
     end
   end
 
@@ -17,7 +17,7 @@ RSpec.describe "MyPage", type: :system do
     end
 
     it "usernameが正しく表示されること" do
-      expect(page).to have_content(user.email)
+      expect(page).to have_content(user.username)
     end
 
     it "emailが正しく表示されること" do
@@ -26,7 +26,7 @@ RSpec.describe "MyPage", type: :system do
 
     it "編集アイコンで編集ページにアクセスできること" do
       find("i.fas.fa-edit").click
-      expect(current_path).to eq(edit_user_registration_path)
+      expect(page).to have_current_path(edit_user_registration_path, ignore_query: true)
     end
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  test "should get show" do
+    get users_show_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
usernameの追加し、user関連のページのulを変更
マイページでユーザーネームとメールアドレスを確認可能に
マイページからユーザー情報の編集をできるように
ユーザーネームのみを変更する時は現在のパスワードを不要に

それぞれrspecを作成