### PR TITLE
schedulerの作成とtaskの作成

### DIFF
--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,0 +1,23 @@
+namespace :scheduler do
+  desc "Migrate live schedules to live records"
+  task migrate_live_schedules: :environment do
+    LiveSchedule.where(date: Date.today).each do |schedule|
+      LiveRecord.create!(
+        name: schedule.name,
+        artist_id: schedule.artist_id,
+        date: schedule.date,
+        start_time: schedule.start_time,
+        venue_id: schedule.venue_id,
+        ticket_price: schedule.ticket_price,
+        drink_price: schedule.drink_price,
+        memo: schedule.memo,
+        user_id: schedule.user_id
+      )
+    end
+  end
+
+  desc "Delete future live schedules from tomorrow onwards"
+  task delete_future_schedules: :environment do
+    LiveSchedule.where('date >= ?', Date.tomorrow).destroy_all
+  end
+end


### PR DESCRIPTION
schedulerの作成とtaskの作成により毎日自動的にtaskの確認をするように設定(heroku上で)
ライブ当日にライブ記録にコピーをし翌日にはライブ予定を削除